### PR TITLE
fix: derrive playlist names in topcard based on time frame of songs

### DIFF
--- a/src/components/Cards/TopCard/TopCard.tsx
+++ b/src/components/Cards/TopCard/TopCard.tsx
@@ -1,4 +1,4 @@
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { SET_PLAYER_URIS } from 'context/user';
 import PlayButton from 'assets/logos/play-button-square.png';
 import PlaylistAdd from 'assets/logos/playlist-add.png';
@@ -7,18 +7,20 @@ import { spotifyApi } from 'spotify';
 import { toast } from 'react-toastify';
 
 const TopCard = (props: TopCardProps) => {
-  const { list, title, userId, playlists } = props;
+  const { list, title, userId, playlists, timeFrame } = props;
   const dispatch = useDispatch();
 
   const createPlaylist = async () => {
-    // get date for playlist name
-    const date = new Date();
-    const month = date.getMonth() + 1; // getMonth() returns 0-11, so add 1 to get 1-12
-    const year = date.getFullYear().toString().slice(-2); // get the last two digits of the year
-    const formattedDate = `${month.toString().padStart(2, '0')}/${year}`;
-
+    let timeRange: string = timeFrame!;
+    if (timeFrame === 'month') {
+      // get date for playlist name
+      const date = new Date();
+      const month = date.getMonth() + 1; // getMonth() returns 0-11, so add 1 to get 1-12
+      const year = date.getFullYear().toString().slice(-2); // get the last two digits of the year
+      timeRange = `${month.toString().padStart(2, '0')}/${year}`;
+    }
     // derrive playlist name from date
-    const playlistName = `Monthly Wrapped (${formattedDate})`;
+    const playlistName = `Monthly Wrapped (${timeRange})`;
 
     // check if playlist already exists
     let playlistExists = false;
@@ -35,7 +37,7 @@ const TopCard = (props: TopCardProps) => {
       const createPlaylistResult = await spotifyApi.createPlaylist(userId!, {
         name: playlistName,
         public: false,
-        description: `My top tracks in ${formattedDate}`,
+        description: `My top tracks ${timeRange}`,
       });
       playlistId = createPlaylistResult.id;
     }
@@ -55,7 +57,7 @@ const TopCard = (props: TopCardProps) => {
             src={PlaylistAdd}
             onClick={createPlaylist}
             alt=""
-            title="Export items to playlist"
+            title="Send items to playlist"
           />
         )}
       </div>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -28,6 +28,7 @@ const Dashboard = (props: DashboardProps) => {
               title="Top Tracks this Month"
               userId={userId}
               playlists={playlists}
+              timeFrame="month"
             />
           </>
         )}
@@ -39,6 +40,7 @@ const Dashboard = (props: DashboardProps) => {
               title="Top Tracks All Time"
               userId={userId}
               playlists={playlists}
+              timeFrame="all-time"
             />
           </>
         )}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -81,6 +81,7 @@ interface TopCardProps {
   list: TopItems[];
   userId?: string;
   playlists?: Playlist[];
+  timeFrame?: 'month' | 'all-time';
 }
 
 interface FloatingCardProps {


### PR DESCRIPTION
# Pull Request
## Linked GH Issues

## Summary of Change
* change method that playlist names are derrived from in TopCard createPlaylist function

## Breaking Changes and Impact/Migration

## Tested With

## Other Information
* note: if you click the "send to playlist" button multiple times without refreshing, and the playlist didn't exist previously, it will keep creating new playlists with the same name and content. This is because the userPlaylists are not updated with the newly created playlist yet. Not sure if the userPlaylists should be stored in redux or not in order to prevent this issue, but the initial issue is fixed for now